### PR TITLE
chore(build): update Caliban from 2.9.0 to 2.9.1

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -20,7 +20,7 @@ def millVersion = T {
 
 object Versions {
   lazy val scala = "2.13.14"
-  lazy val caliban = "2.9.0"
+  lazy val caliban = "2.9.1"
 }
 
 object `mill-caliban` extends ScalaModule with CiReleaseModule with BuildInfo {


### PR DESCRIPTION
release note https://github.com/ghostdogpr/caliban/releases/tag/v2.9.1