### PR TITLE
feat: upgrade caliban to 3.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java-version: [11]
+        java-version: [25]
 
     runs-on: ${{ matrix.os }}
 
@@ -57,10 +57,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 11
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 25
           distribution: temurin
 
       - name: Publish to Maven Central

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java-version: [25]
+        java-version: [17]
 
     runs-on: ${{ matrix.os }}
 
@@ -57,10 +57,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 25
+      - name: Set up JDK
         uses: actions/setup-java@v5
         with:
-          java-version: 25
+          java-version: 17
           distribution: temurin
 
       - name: Publish to Maven Central

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,11 @@ jobs:
         with:
           fetch-depth: 0
           
-      - name: Set up JDK 21
+      - name: Set up JDK
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "17"
           
       - name: Publish to Maven Central
         run: ./mill __.publishSonatypeCentral

--- a/build.mill
+++ b/build.mill
@@ -11,7 +11,7 @@ import mill.util.BuildInfo.{millVersion, millBinPlatform}
 
 object Versions {
   lazy val scala = "3.7.4"
-  lazy val caliban = "2.11.1"
+  lazy val caliban = "3.0.0"
 }
 
 object `mill-caliban` extends ScalaModule with SonatypeCentralPublishModule with BuildInfo {
@@ -52,7 +52,7 @@ object `mill-caliban` extends ScalaModule with SonatypeCentralPublishModule with
   )
 
   override def mvnDeps = super.mvnDeps() ++ Seq(
-    mvn"com.github.ghostdogpr::caliban-tools:${Versions.caliban}"
+    mvn"com.github.ghostdogpr::caliban-codegen:${Versions.caliban}"
   )
 
   override def buildInfoMembers = Seq(

--- a/mill-caliban/src/caliban/codegen/CalibanSourceGenerator.scala
+++ b/mill-caliban/src/caliban/codegen/CalibanSourceGenerator.scala
@@ -2,7 +2,7 @@ package caliban.codegen
 
 import java.io.File
 
-import caliban.tools.Codegen
+import caliban.codegen.Codegen
 import zio.{IO, ZIO}
 
 import io.github.hoangmaihuy.mill.caliban.{CalibanFileSettings, CalibanCommonSettings}

--- a/mill-caliban/src/io/github/hoangmaihuy/mill/caliban/CalibanSettings.scala
+++ b/mill-caliban/src/io/github/hoangmaihuy/mill/caliban/CalibanSettings.scala
@@ -1,6 +1,7 @@
 package io.github.hoangmaihuy.mill.caliban
 
-import caliban.tools.Options
+import caliban.codegen.Options
+import caliban.tools.Header
 import upickle.default.ReadWriter
 
 enum CalibanGenType derives ReadWriter {
@@ -9,9 +10,9 @@ enum CalibanGenType derives ReadWriter {
 
 object CalibanGenType {
 
-  given Conversion[CalibanGenType, caliban.tools.Codegen.GenType] = {
-    case CalibanGenType.Schema => caliban.tools.Codegen.GenType.Schema
-    case CalibanGenType.Client => caliban.tools.Codegen.GenType.Client
+  given Conversion[CalibanGenType, caliban.codegen.Codegen.GenType] = {
+    case CalibanGenType.Schema => caliban.codegen.Codegen.GenType.Schema
+    case CalibanGenType.Client => caliban.codegen.Codegen.GenType.Client
   }
 
 }
@@ -80,7 +81,7 @@ final case class CalibanCommonSettings(
       schemaPath = schemaPath,
       toPath = toPath,
       fmtPath = scalafmtPath,
-      headers = Option(headers.map((Options.Header.apply).tupled).toList).filter(_.nonEmpty),
+      headers = Option(headers.map((Header.apply).tupled).toList).filter(_.nonEmpty),
       packageName = packageName,
       clientName = clientName,
       genView = genView,


### PR DESCRIPTION
Adapt to caliban 3.0.0 module split: caliban-tools was split into caliban-codegen + caliban-tools. Update dependency and imports accordingly.